### PR TITLE
update for new DebugFlags capability semantics

### DIFF
--- a/sysmodule/sysmodule.json
+++ b/sysmodule/sysmodule.json
@@ -165,8 +165,9 @@
 		}, {
 			"type":	"debug_flags",
 			"value":	{
-				"allow_debug":	false,
-				"force_debug":	true
+				"allow_debug":	true,
+				"force_debug_prod":	false,
+				"force_debug":	false
 			}
 		}]
 }


### PR DESCRIPTION
1. You don't need force_debug
2. You won't be able to compile it without this PR from now on with newest switch-tools